### PR TITLE
Support for .url() on InMemoryStorage

### DIFF
--- a/inmemorystorage/storage.py
+++ b/inmemorystorage/storage.py
@@ -91,8 +91,12 @@ class InMemoryStorage(Storage):
     """
     Django storage class for in-memory filesystem.
     """
-    def __init__(self, filesystem=None):
+    def __init__(self, filesystem=None, base_url=None):
         self.filesystem = filesystem or InMemoryDir()
+        
+        if base_url is None:
+            base_url = settings.MEDIA_URL
+        self.base_url = base_url
 
     def listdir(self, dir):
         return self.filesystem.listdir(dir)
@@ -111,3 +115,9 @@ class InMemoryStorage(Storage):
 
     def _save(self, name, content):
         return self.filesystem.save(name, content.read())
+    
+    def url(self, name):
+        if self.base_url is None:
+            raise ValueError("This file is not accessible via a URL.")
+        return urlparse.urljoin(self.base_url, filepath_to_uri(name))
+

--- a/inmemorystorage/storage.py
+++ b/inmemorystorage/storage.py
@@ -1,5 +1,9 @@
+import urlparse
+
+from django.conf import settings
 from django.core.files.storage import Storage
 from django.core.files.base import ContentFile
+from django.utils.encoding import filepath_to_uri
 
 class PathDoesNotExist(Exception):
     pass


### PR DESCRIPTION
I made some changes which let you access the ".url" property of models.FileFields without an exception being thrown. Though the URLs aren't actually accessible, the lack of exceptions does allow for InMemoryStorage to be used as a mock storage object during testing.
